### PR TITLE
Fixed bottom padding for menu items

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -280,7 +280,7 @@ nav ul a {
 	color: #000;
 	text-decoration: none;
 	display: block;
-	padding: 1.9em 0.4em;
+	padding: 1.9em 0.4em 1.5em 0.4em;
 }
 
 nav ul .sub-menu {


### PR DESCRIPTION
Би трябвало да спре местенето на openfest логото при hover на менютата. Fix-а се базира на предложението на @ignisf в този pull request - #15. Гледахме го с @herince  и изглежда да работи.

Можете да тествате на http://dev.openfest.org.